### PR TITLE
Support non-pow-2 textures

### DIFF
--- a/examples/blend.rs
+++ b/examples/blend.rs
@@ -71,7 +71,7 @@ async fn app(
 }
 
 fn main() {
-    run_gl(Settings::default(), |window, gfx, events| {
-        async move { app(window, gfx, events).await.unwrap() }
+    run_gl(Settings::default(), |window, gfx, events| async move {
+        app(window, gfx, events).await.unwrap()
     });
 }

--- a/examples/geometry.rs
+++ b/examples/geometry.rs
@@ -59,7 +59,7 @@ async fn app(
 }
 
 fn main() {
-    run_gl(Settings::default(), |window, gfx, events| {
-        async move { app(window, gfx, events).await.unwrap() }
+    run_gl(Settings::default(), |window, gfx, events| async move {
+        app(window, gfx, events).await.unwrap()
     });
 }

--- a/examples/hello-triangle.rs
+++ b/examples/hello-triangle.rs
@@ -98,7 +98,7 @@ async fn app(
 
 // Run our application!
 fn main() {
-    run_gl(Settings::default(), |window, gfx, events| {
-        async move { app(window, gfx, events).await.unwrap() }
+    run_gl(Settings::default(), |window, gfx, events| async move {
+        app(window, gfx, events).await.unwrap()
     });
 }

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -76,7 +76,7 @@ async fn app(
 }
 
 fn main() {
-    run_gl(Settings::default(), |window, gfx, events| {
-        async move { app(window, gfx, events).await.unwrap() }
+    run_gl(Settings::default(), |window, gfx, events| async move {
+        app(window, gfx, events).await.unwrap()
     });
 }

--- a/examples/surfaces.rs
+++ b/examples/surfaces.rs
@@ -135,7 +135,7 @@ async fn app(
 }
 
 fn main() {
-    run_gl(Settings::default(), |window, gfx, events| {
-        async move { app(window, gfx, events).await.unwrap() }
+    run_gl(Settings::default(), |window, gfx, events| async move {
+        app(window, gfx, events).await.unwrap()
     });
 }

--- a/examples/surfaces.rs
+++ b/examples/surfaces.rs
@@ -48,7 +48,7 @@ async fn app(
     eb.set_data(&indices);
     shader.bind();
     let mut backing_texture = Texture::new(ctx)?;
-    backing_texture.set_image(None, 128, 128, ColorFormat::RGBA);
+    backing_texture.set_image(None, 100, 100, ColorFormat::RGBA);
     ctx.set_viewport(0, 0, backing_texture.width(), backing_texture.height());
     let mut surface = Surface::new(ctx, backing_texture)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,8 +195,12 @@ pub enum GolemError {
     NotCurrentProgram,
     /// A texture filter requiring mipmaps was used when mipmaps were unavailable
     ///
-    /// Mipmaps are only available for minification, and only for power-of-two sized textures
+    /// Mipmaps are only available for minification, and only for power-of-two sized textures (2x2, 4x4, etc.)
     MipMapsUnavailable,
+    /// A wrap option was set for a Texture that isn't available
+    ///
+    /// Texture repeats are currently only supported for power-of-2 sized textures (2x2, 4x4, etc.)
+    IllegalWrapOption,
 }
 
 impl From<String> for GolemError {

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -233,7 +233,7 @@ pub enum TextureFilter {
 }
 
 impl TextureFilter {
-    pub(crate) fn to_gl(&self) -> i32 {
+    pub(crate) fn to_gl(self) -> i32 {
         match self {
             TextureFilter::Linear => glow::LINEAR as i32,
             TextureFilter::Nearest => glow::NEAREST as i32,
@@ -247,7 +247,7 @@ impl TextureFilter {
     /// If this texture filter uses texture mipmaps
     ///
     /// Mipmaps are only available for power-of-two textures, and only available for minification
-    pub fn uses_mipmap(&self) -> bool {
+    pub fn uses_mipmap(self) -> bool {
         match self {
             TextureFilter::Linear | TextureFilter::Nearest => false,
             _ => true,
@@ -267,7 +267,7 @@ pub enum TextureWrap {
 }
 
 impl TextureWrap {
-    pub(crate) fn to_gl(&self) -> i32 {
+    pub(crate) fn to_gl(self) -> i32 {
         match self {
             TextureWrap::Repeat => glow::REPEAT as i32,
             TextureWrap::ClampToEdge => glow::CLAMP_TO_EDGE as i32,


### PR DESCRIPTION
The groundwork for this was laid in #18 but these changes are necessary to expose non-pow-2 functionality.