### PR TITLE
Fixed depth test on web

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -170,7 +170,9 @@ impl Context {
                 // The to_gl() function only produces valid values
                 gl.depth_func(function.to_gl());
                 // https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDepthRange.xhtml
-                gl.depth_range_f64(range_near, range_far);
+                // https://www.khronos.org/registry/OpenGL-Refpages/es3.0/html/glDepthRangef.xhtml
+                // Minimal OpenGL version is 4.1
+                gl.depth_range_f32(range_near, range_far);
                 // https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDepthMask.xhtml
                 gl.depth_mask(depth_mask);
             },

--- a/src/context.rs
+++ b/src/context.rs
@@ -169,10 +169,15 @@ impl Context {
                 // https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDepthFunc.xhtml
                 // The to_gl() function only produces valid values
                 gl.depth_func(function.to_gl());
+
                 // https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDepthRange.xhtml
+                #[cfg(not(target_arch = "wasm32"))]
+                gl.depth_range_f64(range_near as f64, range_far as f64);
+
                 // https://www.khronos.org/registry/OpenGL-Refpages/es3.0/html/glDepthRangef.xhtml
-                // Minimal OpenGL version is 4.1
+                #[cfg(target_arch = "wasm32")]
                 gl.depth_range_f32(range_near, range_far);
+
                 // https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDepthMask.xhtml
                 gl.depth_mask(depth_mask);
             },

--- a/src/depth.rs
+++ b/src/depth.rs
@@ -13,20 +13,20 @@ pub struct DepthTestMode {
     pub function: DepthTestFunction,
     /// Specifies the mapping of the near clipping plane to window coordinates
     ///
-    /// Default is `0.0f64`.
-    pub range_near: f64,
+    /// Default is `0.0f32`.
+    pub range_near: f32,
     /// Specifies the mapping of the far clipping plane to window coordinates
     ///
-    /// Default is `1.0f64`.
-    pub range_far: f64,
+    /// Default is `1.0f32`.
+    pub range_far: f32,
     /// Specifies whether the depth buffer is enabled for writing
     ///
     /// Default is `true`, i.e. "writing is enabled".
     ///
     /// Making the depth buffer read-only is useful for situations where you still want
     /// depth tests to occur, but don't want to overwrite the values already in the depth buffer;
-    /// for example, common way of rendering scenes with a mix of opaque translucent objects is
-    /// to render opaque ones first, then disable depth mask and render translucent ones
+    /// for example, common way of rendering scenes with a mix of opaque and translucent objects
+    /// is to render opaque ones first, then disable depth mask and render translucent ones
     /// from back to front.
     pub depth_mask: bool,
 }


### PR DESCRIPTION
Follow-up to #29.

Depth range is now specified in `f32` rather than `f64`; this pegs minimum supported OpenGL version on desktop at [4.1](https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glDepthRange.xhtml).