### PR TITLE
Fix dangling vertex attributes

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -13,6 +13,7 @@ pub(crate) struct ContextContents {
     pub(crate) current_program: RefCell<Option<GlProgram>>,
     pub(crate) current_surface: RefCell<Option<GlFramebuffer>>,
     vao: GlVertexArray,
+    max_vertex_attrib_index: RefCell<u32>,
 }
 
 impl Drop for ContextContents {
@@ -45,6 +46,7 @@ impl Context {
             current_program: RefCell::new(None),
             current_surface: RefCell::new(None),
             vao,
+            max_vertex_attrib_index: RefCell::new(0),
         }));
         contents.set_clear_color(0.0, 0.0, 0.0, 1.0);
 
@@ -186,5 +188,14 @@ impl Context {
                 gl.disable(glow::DEPTH_TEST);
             },
         }
+    }
+
+    /// Set the new max attribute, clear the old one
+    pub(crate) fn max_attrib(&self, index: u32) -> u32 {
+        let mut attrib_ptr = self.0.max_vertex_attrib_index.borrow_mut();
+        let attrib = *attrib_ptr;
+        *attrib_ptr = index;
+
+        attrib
     }
 }

--- a/src/shader.rs
+++ b/src/shader.rs
@@ -306,6 +306,14 @@ impl ShaderProgram {
                 }
                 offset += size * size_of::<f32>() as i32;
             }
+            // Disable any dangling vertex attributes
+            let current_max_attrib = self.input.len() as u32;
+            let previous_max_attrib = self.ctx.max_attrib(current_max_attrib);
+            for i in current_max_attrib..previous_max_attrib {
+                unsafe {
+                    gl.disable_vertex_attrib_array(i);
+                }
+            }
 
             Ok(())
         }


### PR DESCRIPTION
When you prepare to draw with a shader that has fewer attributes than the previous shader, this would previously cause an error.

Resolve #35 