### PR TITLE
Update glow and remove it from the public API

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -51,8 +51,8 @@ jobs:
       run: sudo apt update && sudo apt install libudev-dev
     - name: Clippy
       run: cargo clippy -- -D warnings
-    - name: Featureless clipppy
-      run: cargo clippy --no-default-features -- -D warnings
+    - name: Clippy with std
+      run: cargo clippy --features std -- -D warnings
 
   web-check:
     runs-on: macOS-latest
@@ -62,7 +62,7 @@ jobs:
         rust-version: ${{ matrix.rust }}
         targets: wasm32-unknown-unknown
     - uses: actions/checkout@master
-    - name: Check stdweb
-      run: cargo install cargo-web && cargo web check --features stdweb
-    - name: Clippy
-      run: cargo check --target wasm32-unknown-unknown --features web-sys
+    - name: Check web
+      run: cargo check --target wasm32-unknown-unknown
+    - name: Check web std
+      run: cargo check --target wasm32-unknown-unknown --features std

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,15 +11,19 @@ repository = "https://github.com/ryanisaacg/golem"
 readme = "README.md"
 
 [features]
-stdweb = ["glow/stdweb"]
-web-sys = ["glow/web-sys"]
 std = []
 
 [dependencies]
 bytemuck = "1"
-glow = { version = "0.4.0", default-features = false }
 log = "0.4"
 
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+glow = { version = "0.6.0", default-features = false }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+glow = { version = "0.6.0", default-features = false, features = ["web-sys"] }
+web-sys = { version = "0.3", features = ["WebGlRenderingContext"] }
+
 [dev-dependencies]
-blinds = { version = "0.1.0", default-features = false, features = ["gl"] }
+blinds = { version = "0.2.0", default-features = false }
 nalgebra-glm = "0.7.0"

--- a/examples/3d_scene.rs
+++ b/examples/3d_scene.rs
@@ -11,10 +11,13 @@ use nalgebra_glm as glm;
 
 async fn app(
     window: Window,
-    ctx: golem::glow::Context,
     mut events: EventStream,
 ) -> Result<(), GolemError> {
-    let ctx = &Context::from_glow(ctx)?;
+    // On desktop and web, we have to load the context slightly differently
+    #[cfg(not(target_arch = "wasm32"))]
+    let ctx = Context::from_loader_function(|addr| window.get_proc_address(addr))?;
+    #[cfg(target_arch = "wasm32")]
+    let ctx = Context::from_webgl_context(window.webgl_context())?;
 
     // A cube
     #[rustfmt::skip]
@@ -39,7 +42,7 @@ async fn app(
     ];
 
     let mut shader = ShaderProgram::new(
-        ctx,
+        &ctx,
         ShaderDescription {
             vertex_input: &[Attribute::new("vert_position", AttributeType::Vector(D3))],
             fragment_input: &[],
@@ -58,8 +61,8 @@ async fn app(
         },
     )?;
 
-    let mut vb = VertexBuffer::new(ctx)?;
-    let mut eb = ElementBuffer::new(ctx)?;
+    let mut vb = VertexBuffer::new(&ctx)?;
+    let mut eb = ElementBuffer::new(&ctx)?;
     vb.set_data(&vertices);
     eb.set_data(&indices);
     ctx.clear();
@@ -152,7 +155,7 @@ async fn app(
 }
 
 fn main() {
-    run_gl(Settings::default(), |window, gfx, events| async move {
-        app(window, gfx, events).await.unwrap()
+    run(Settings::default(), |window, events| async move {
+        app(window, events).await.unwrap()
     });
 }

--- a/examples/3d_scene.rs
+++ b/examples/3d_scene.rs
@@ -9,10 +9,7 @@ use golem::{
 };
 use nalgebra_glm as glm;
 
-async fn app(
-    window: Window,
-    mut events: EventStream,
-) -> Result<(), GolemError> {
+async fn app(window: Window, mut events: EventStream) -> Result<(), GolemError> {
     // On desktop and web, we have to load the context slightly differently
     #[cfg(not(target_arch = "wasm32"))]
     let ctx = Context::from_loader_function(|addr| window.get_proc_address(addr))?;

--- a/examples/blend.rs
+++ b/examples/blend.rs
@@ -7,10 +7,7 @@ use golem::{
     UniformType, UniformValue, VertexBuffer,
 };
 
-async fn app(
-    window: Window,
-    mut events: EventStream,
-) -> Result<(), GolemError> {
+async fn app(window: Window, mut events: EventStream) -> Result<(), GolemError> {
     // On desktop and web, we have to load the context slightly differently
     #[cfg(not(target_arch = "wasm32"))]
     let ctx = Context::from_loader_function(|addr| window.get_proc_address(addr))?;

--- a/examples/blend.rs
+++ b/examples/blend.rs
@@ -9,10 +9,13 @@ use golem::{
 
 async fn app(
     window: Window,
-    ctx: golem::glow::Context,
     mut events: EventStream,
 ) -> Result<(), GolemError> {
-    let ctx = &Context::from_glow(ctx)?;
+    // On desktop and web, we have to load the context slightly differently
+    #[cfg(not(target_arch = "wasm32"))]
+    let ctx = Context::from_loader_function(|addr| window.get_proc_address(addr))?;
+    #[cfg(target_arch = "wasm32")]
+    let ctx = Context::from_webgl_context(window.webgl_context())?;
 
     #[rustfmt::skip]
     let vertices = [
@@ -25,7 +28,7 @@ async fn app(
     let indices = [0, 1, 2, 2, 3, 0];
 
     let mut shader = ShaderProgram::new(
-        ctx,
+        &ctx,
         ShaderDescription {
             vertex_input: &[Attribute::new("vert_position", AttributeType::Vector(D2))],
             fragment_input: &[],
@@ -42,8 +45,8 @@ async fn app(
         },
     )?;
 
-    let mut vb = VertexBuffer::new(ctx)?;
-    let mut eb = ElementBuffer::new(ctx)?;
+    let mut vb = VertexBuffer::new(&ctx)?;
+    let mut eb = ElementBuffer::new(&ctx)?;
     vb.set_data(&vertices);
     eb.set_data(&indices);
     ctx.clear();
@@ -71,7 +74,7 @@ async fn app(
 }
 
 fn main() {
-    run_gl(Settings::default(), |window, gfx, events| async move {
-        app(window, gfx, events).await.unwrap()
+    run(Settings::default(), |window, events| async move {
+        app(window, events).await.unwrap()
     });
 }

--- a/examples/depth.rs
+++ b/examples/depth.rs
@@ -7,10 +7,7 @@ use golem::{
     UniformType, UniformValue, VertexBuffer,
 };
 
-async fn app(
-    window: Window,
-    mut events: EventStream,
-) -> Result<(), GolemError> {
+async fn app(window: Window, mut events: EventStream) -> Result<(), GolemError> {
     // On desktop and web, we have to load the context slightly differently
     #[cfg(not(target_arch = "wasm32"))]
     let ctx = Context::from_loader_function(|addr| window.get_proc_address(addr))?;

--- a/examples/geometry.rs
+++ b/examples/geometry.rs
@@ -5,10 +5,7 @@ use golem::{
     ElementBuffer, GeometryMode, GolemError, ShaderDescription, ShaderProgram, VertexBuffer,
 };
 
-async fn app(
-    window: Window,
-    mut events: EventStream,
-) -> Result<(), GolemError> {
+async fn app(window: Window, mut events: EventStream) -> Result<(), GolemError> {
     // On desktop and web, we have to load the context slightly differently
     #[cfg(not(target_arch = "wasm32"))]
     let ctx = Context::from_loader_function(|addr| window.get_proc_address(addr))?;

--- a/examples/geometry.rs
+++ b/examples/geometry.rs
@@ -7,10 +7,13 @@ use golem::{
 
 async fn app(
     window: Window,
-    ctx: golem::glow::Context,
     mut events: EventStream,
 ) -> Result<(), GolemError> {
-    let ctx = &Context::from_glow(ctx)?;
+    // On desktop and web, we have to load the context slightly differently
+    #[cfg(not(target_arch = "wasm32"))]
+    let ctx = Context::from_loader_function(|addr| window.get_proc_address(addr))?;
+    #[cfg(target_arch = "wasm32")]
+    let ctx = Context::from_webgl_context(window.webgl_context())?;
 
     #[rustfmt::skip]
     let vertices = [
@@ -23,7 +26,7 @@ async fn app(
     let indices = [0, 1, 1, 2, 2, 3, 3, 0];
 
     let mut shader = ShaderProgram::new(
-        ctx,
+        &ctx,
         ShaderDescription {
             vertex_input: &[
                 Attribute::new("vert_position", AttributeType::Vector(D2)),
@@ -41,8 +44,8 @@ async fn app(
         },
     )?;
 
-    let mut vb = VertexBuffer::new(ctx)?;
-    let mut eb = ElementBuffer::new(ctx)?;
+    let mut vb = VertexBuffer::new(&ctx)?;
+    let mut eb = ElementBuffer::new(&ctx)?;
     vb.set_data(&vertices);
     eb.set_data(&indices);
     shader.bind();
@@ -59,7 +62,7 @@ async fn app(
 }
 
 fn main() {
-    run_gl(Settings::default(), |window, gfx, events| async move {
-        app(window, gfx, events).await.unwrap()
+    run(Settings::default(), |window, events| async move {
+        app(window, events).await.unwrap()
     });
 }

--- a/examples/hello-triangle.rs
+++ b/examples/hello-triangle.rs
@@ -6,10 +6,7 @@ use golem::{
 };
 
 // The application loop, powered by the blinds crate
-async fn app(
-    window: Window,
-    mut events: EventStream,
-) -> Result<(), GolemError> {
+async fn app(window: Window, mut events: EventStream) -> Result<(), GolemError> {
     // On desktop and web, we have to load the context slightly differently
     #[cfg(not(target_arch = "wasm32"))]
     let ctx = Context::from_loader_function(|addr| window.get_proc_address(addr))?;

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -5,10 +5,7 @@ use golem::{
     VertexBuffer,
 };
 
-async fn app(
-    window: Window,
-    mut events: EventStream,
-) -> Result<(), GolemError> {
+async fn app(window: Window, mut events: EventStream) -> Result<(), GolemError> {
     // On desktop and web, we have to load the context slightly differently
     #[cfg(not(target_arch = "wasm32"))]
     let ctx = Context::from_loader_function(|addr| window.get_proc_address(addr))?;

--- a/examples/surfaces.rs
+++ b/examples/surfaces.rs
@@ -6,10 +6,7 @@ use golem::{
     Texture, Uniform, UniformType, UniformValue, VertexBuffer,
 };
 
-async fn app(
-    window: Window,
-    mut events: EventStream,
-) -> Result<(), GolemError> {
+async fn app(window: Window, mut events: EventStream) -> Result<(), GolemError> {
     // On desktop and web, we have to load the context slightly differently
     #[cfg(not(target_arch = "wasm32"))]
     let ctx = Context::from_loader_function(|addr| window.get_proc_address(addr))?;

--- a/examples/surfaces.rs
+++ b/examples/surfaces.rs
@@ -8,10 +8,13 @@ use golem::{
 
 async fn app(
     window: Window,
-    ctx: golem::glow::Context,
     mut events: EventStream,
 ) -> Result<(), GolemError> {
-    let ctx = &Context::from_glow(ctx)?;
+    // On desktop and web, we have to load the context slightly differently
+    #[cfg(not(target_arch = "wasm32"))]
+    let ctx = Context::from_loader_function(|addr| window.get_proc_address(addr))?;
+    #[cfg(target_arch = "wasm32")]
+    let ctx = Context::from_webgl_context(window.webgl_context())?;
 
     // Step 1: Draw a triangle to the surface
     #[rustfmt::skip]
@@ -24,7 +27,7 @@ async fn app(
     let indices = [0, 1, 2];
 
     let mut shader = ShaderProgram::new(
-        ctx,
+        &ctx,
         ShaderDescription {
             vertex_input: &[
                 Attribute::new("vert_position", AttributeType::Vector(D2)),
@@ -42,22 +45,22 @@ async fn app(
         },
     )?;
 
-    let mut vb = VertexBuffer::new(ctx)?;
-    let mut eb = ElementBuffer::new(ctx)?;
+    let mut vb = VertexBuffer::new(&ctx)?;
+    let mut eb = ElementBuffer::new(&ctx)?;
     vb.set_data(&vertices);
     eb.set_data(&indices);
     shader.bind();
-    let mut backing_texture = Texture::new(ctx)?;
+    let mut backing_texture = Texture::new(&ctx)?;
     backing_texture.set_image(None, 100, 100, ColorFormat::RGBA);
     ctx.set_viewport(0, 0, backing_texture.width(), backing_texture.height());
-    let surface = Surface::new(ctx, backing_texture)?;
+    let surface = Surface::new(&ctx, backing_texture)?;
 
     surface.bind();
     ctx.clear();
     unsafe {
         shader.draw(&vb, &eb, 0..indices.len(), GeometryMode::Triangles)?;
     }
-    Surface::unbind(ctx);
+    Surface::unbind(&ctx);
 
     let size = window.size();
     let scale = window.scale_factor();
@@ -75,7 +78,7 @@ async fn app(
     ];
     let indices = [0, 1, 2, 2, 3, 0];
     let mut shader = ShaderProgram::new(
-        ctx,
+        &ctx,
         ShaderDescription {
             vertex_input: &[
                 Attribute::new("vert_position", AttributeType::Vector(D2)),
@@ -137,7 +140,7 @@ async fn app(
 }
 
 fn main() {
-    run_gl(Settings::default(), |window, gfx, events| async move {
-        app(window, gfx, events).await.unwrap()
+    run(Settings::default(), |window, events| async move {
+        app(window, events).await.unwrap()
     });
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -30,7 +30,9 @@ impl Drop for ContextContents {
 impl Context {
     /// Create an instance from a loader function
     #[cfg(not(target_arch = "wasm32"))]
-    pub fn from_loader_function(func: impl FnMut(&str) -> *const core::ffi::c_void) -> Result<Context, GolemError> {
+    pub fn from_loader_function(
+        func: impl FnMut(&str) -> *const core::ffi::c_void,
+    ) -> Result<Context, GolemError> {
         Self::from_glow(unsafe { glow::Context::from_loader_function(func) })
     }
 

--- a/src/shader.rs
+++ b/src/shader.rs
@@ -200,6 +200,7 @@ impl ShaderProgram {
             if location.is_none() {
                 return Err(GolemError::NoSuchUniform(name.to_owned()));
             }
+            let location = location.as_ref();
             use UniformValue::*;
             unsafe {
                 match uniform {

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -153,6 +153,7 @@ impl Surface {
         let gl = &self.ctx.0.gl;
         unsafe {
             gl.bind_framebuffer(glow::FRAMEBUFFER, Some(self.id));
+            let data = glow::PixelPackData::Slice(data);
             gl.read_pixels(
                 x as i32,
                 y as i32,

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -146,7 +146,8 @@ impl Texture {
         let gl = &self.ctx.0.gl;
         unsafe {
             gl.bind_texture(glow::TEXTURE_2D, Some(self.id));
-            gl.tex_sub_image_2d_u8_slice(
+            let data = glow::PixelUnpackData::Slice(data);
+            gl.tex_sub_image_2d(
                 glow::TEXTURE_2D,
                 0,
                 x as i32,
@@ -155,7 +156,7 @@ impl Texture {
                 height as i32,
                 format,
                 glow::UNSIGNED_BYTE,
-                Some(data),
+                data,
             );
             gl.generate_mipmap(glow::TEXTURE_2D);
             gl.bind_texture(glow::TEXTURE_2D, None);


### PR DESCRIPTION
Users shouldn't be subjected to breaking golem changes for every single glow breakage (which are pretty common, because glow has a bigger API surface.)

Additionally, stdweb is not longer a priority because it is unmaintained. Only web-sys will be supported going forward.

Closes #33 